### PR TITLE
feature/0008/gitsigns

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,6 +15,7 @@ require "zeronvim.plugins.indentlines"
 require "zeronvim.plugins.nvim-tree"
 require "zeronvim.plugins.comment"
 require "zeronvim.plugins.navic"
+require "zeronvim.plugins.gitsigns"
 
 -- Completion
 require "zeronvim.plugins.cmp"

--- a/lua/zeronvim/keymaps.lua
+++ b/lua/zeronvim/keymaps.lua
@@ -16,7 +16,6 @@ keymap("", "<Space>", "<Nop>", opts)
 vim.g.mapleader = " "
 vim.g.maplocalleader = " "
 
-
 keymap("n", "<Leader>source", source_config, {})
 
 -- Window Navigation
@@ -50,3 +49,9 @@ keymap('n', '<leader>fh', telescope_builtin.help_tags, {})
 
 -- Formatting
 keymap('n', '<leader>fmt', '<cmd>lua vim.lsp.buf.format({ async = true })<cr>', opts)
+
+-- Git
+keymap('n', '<leader>gblame', '<cmd>:Gitsigns toggle_current_line_blame<cr>')
+keymap('n', '<leader>gnum', '<cmd>:Gitsigns toggle_numhl<cr>')
+keymap('n', '<leader>glh', '<cmd>:Gitsigns toggle_linehl<cr>')
+keymap('n', '<leader>gwd', '<cmd>:Gitsigns toggle_word_diff<cr>')

--- a/lua/zeronvim/plugins.lua
+++ b/lua/zeronvim/plugins.lua
@@ -71,6 +71,9 @@ return packer.startup(function(use)
   -- Icons
   use { "nvim-tree/nvim-web-devicons" }
 
+  -- Gitsigns
+  use { "lewis6991/gitsigns.nvim" }
+
   -- Comments
   use { "numToStr/Comment.nvim" }
 

--- a/lua/zeronvim/plugins/gitsigns.lua
+++ b/lua/zeronvim/plugins/gitsigns.lua
@@ -1,0 +1,49 @@
+local utils = require "zeronvim.utils"
+local gitsigns = utils.protected_plugin_call("gitsigns")
+
+if gitsigns then
+  gitsigns.setup(
+    require('gitsigns').setup {
+      signs                        = {
+        add = { hl = "GitSignsAdd", text = "▎", numhl = "GitSignsAddNr", linehl = "GitSignsAddLn" },
+        change = { hl = "GitSignsChange", text = "▎", numhl = "GitSignsChangeNr", linehl = "GitSignsChangeLn" },
+        delete = { hl = "GitSignsDelete", text = "契", numhl = "GitSignsDeleteNr", linehl = "GitSignsDeleteLn" },
+        topdelete = { hl = "GitSignsDelete", text = "契", numhl = "GitSignsDeleteNr", linehl = "GitSignsDeleteLn" },
+        changedelete = { hl = "GitSignsChange", text = "▎", numhl = "GitSignsChangeNr", linehl = "GitSignsChangeLn" },
+        untracked = { hl = 'GitSignsAdd', text = '┆', numhl = 'GitSignsAddNr', linehl = 'GitSignsAddLn' },
+      },
+      signcolumn                   = true, -- Toggle with `:Gitsigns toggle_signs`
+      numhl                        = false, -- Toggle with `:Gitsigns toggle_numhl`
+      linehl                       = false, -- Toggle with `:Gitsigns toggle_linehl`
+      word_diff                    = false, -- Toggle with `:Gitsigns toggle_word_diff`
+      watch_gitdir                 = {
+        interval = 1000,
+        follow_files = true
+      },
+      attach_to_untracked          = true,
+      current_line_blame           = false, -- Toggle with `:Gitsigns toggle_current_line_blame`
+      current_line_blame_opts      = {
+        virt_text = true,
+        virt_text_pos = 'eol', -- 'eol' | 'overlay' | 'right_align'
+        delay = 1000,
+        ignore_whitespace = false,
+      },
+      current_line_blame_formatter = '<author>, <author_time:%Y-%m-%d> - <summary>',
+      sign_priority                = 6,
+      update_debounce              = 100,
+      status_formatter             = nil, -- Use default
+      max_file_length              = 40000, -- Disable if file is longer than this (in lines)
+      preview_config               = {
+        -- Options passed to nvim_open_win
+        border = 'single',
+        style = 'minimal',
+        relative = 'cursor',
+        row = 0,
+        col = 1
+      },
+      yadm                         = {
+        enable = false
+      },
+    }
+  )
+end


### PR DESCRIPTION
- feat: add util function, get-file-extension, get-filename, is-input-empty
- feat: add error to sourcing, if present
- feat: add error to protected-plugin-call if error occures
- feat: add get-buf-option function
- feat: enable colorscheme for navic
- fix: fix indentlines, typo in plugin name
- style: fix formatting
- feat: attach nvim-navic to lsp-handlers
- feat: add navic setup
- refactor: change how configuration sourcing is called
- refactor: reoder plugins
- feat: add first working draft for winbar/breadcrumbs with nvim-navic
- refactor: remove empty lines
- feat: add gitsigns plugin, configuration and keymaps
